### PR TITLE
WIP: add ValueRate and scale points by ValueRate while rebuilding

### DIFF
--- a/library/bdBank/ControllerAdmin/ValueRate.php
+++ b/library/bdBank/ControllerAdmin/ValueRate.php
@@ -1,0 +1,118 @@
+<?php
+
+class bdBank_ControllerAdmin_ValueRate extends XenForo_ControllerAdmin_Abstract
+{
+
+    /* Start auto-generated lines of code. Change made will be overwriten... */
+
+    public function actionSave()
+    {
+        $this->_assertPostOnly();
+
+        $id = $this->_input->filterSingle('rate_id', XenForo_Input::UINT);
+        $dw = $this->_getValueRateDataWriter();
+        if ($id) {
+            $dw->setExistingData($id);
+        }
+
+        // get regular fields from input data
+        $dwInput = $this->_input->filter(array('rate' => 'float', 'valid_to' => 'uint'));
+        $dw->bulkSet($dwInput);
+
+        $this->_prepareDwBeforeSaving($dw);
+
+        $dw->save();
+
+        return $this->responseRedirect(
+            XenForo_ControllerResponse_Redirect::SUCCESS,
+            XenForo_Link::buildAdminLink('value-rates')
+        );
+    }
+
+    public function actionIndex()
+    {
+        $conditions = array();
+        $fetchOptions = array();
+
+        $valueRateModel = $this->_getValueRateModel();
+        $valueRates = $valueRateModel->getValueRates($conditions, $fetchOptions);
+
+        $viewParams = array(
+            'valueRates' => $valueRates,
+        );
+
+        return $this->responseView('bdBank_ViewAdmin_ValueRate_List', 'bdbank_value_rate_list', $viewParams);
+    }
+
+    public function actionAdd()
+    {
+        $viewParams = array(
+            'valueRate' => array(),
+        );
+
+        return $this->responseView('bdBank_ViewAdmin_ValueRate_Edit', 'bdbank_value_rate_edit', $viewParams);
+    }
+
+    public function actionEdit()
+    {
+        $id = $this->_input->filterSingle('rate_id', XenForo_Input::UINT);
+        $valueRate = $this->_getValueRateOrError($id);
+
+        $viewParams = array(
+            'valueRate' => $valueRate,
+        );
+
+        return $this->responseView('bdBank_ViewAdmin_ValueRate_Edit', 'bdbank_value_rate_edit', $viewParams);
+    }
+
+    public function actionDelete()
+    {
+        $id = $this->_input->filterSingle('rate_id', XenForo_Input::UINT);
+        $valueRate = $this->_getValueRateOrError($id);
+
+        if ($this->isConfirmedPost()) {
+            $dw = $this->_getValueRateDataWriter();
+            $dw->setExistingData($id);
+            $dw->delete();
+
+            return $this->responseRedirect(
+                XenForo_ControllerResponse_Redirect::SUCCESS,
+                XenForo_Link::buildAdminLink('value-rates')
+            );
+        } else {
+            $viewParams = array(
+                'valueRate' => $valueRate,
+            );
+
+            return $this->responseView('bdBank_ViewAdmin_ValueRate_Delete', 'bdbank_value_rate_delete', $viewParams);
+        }
+    }
+
+    protected function _getValueRateOrError($id, array $fetchOptions = array())
+    {
+        $valueRate = $this->_getValueRateModel()->getValueRateById($id, $fetchOptions);
+
+        if (empty($valueRate)) {
+            throw $this->responseException($this->responseError(new XenForo_Phrase('bdbank_value_rate_not_found'), 404));
+        }
+
+        return $valueRate;
+    }
+
+    protected function _getValueRateModel()
+    {
+        return $this->getModelFromCache('bdBank_Model_ValueRate');
+    }
+
+    protected function _getValueRateDataWriter()
+    {
+        return XenForo_DataWriter::create('bdBank_DataWriter_ValueRate');
+    }
+
+    /* End auto-generated lines of code. Feel free to make changes below */
+
+    protected function _prepareDwBeforeSaving(bdBank_DataWriter_ValueRate $dw)
+    {
+        // customized code goes here
+    }
+}

--- a/library/bdBank/DataWriter/ValueRate.php
+++ b/library/bdBank/DataWriter/ValueRate.php
@@ -1,0 +1,48 @@
+<?php
+
+class bdBank_DataWriter_ValueRate extends XenForo_DataWriter
+{
+
+    /* Start auto-generated lines of code. Change made will be overwriten... */
+
+    protected function _getFields()
+    {
+        return array(
+            'xf_bdbank_value_rate' => array(
+                'rate_id' => array('type' => XenForo_DataWriter::TYPE_UINT, 'autoIncrement' => true),
+                'rate' => array('type' => XenForo_DataWriter::TYPE_FLOAT, 'required' => true),
+                'valid_to' => array('type' => XenForo_DataWriter::TYPE_UINT, 'required' => true),
+            )
+        );
+    }
+
+    protected function _getExistingData($data)
+    {
+        if (!$id = $this->_getExistingPrimaryKey($data, 'rate_id')) {
+            return false;
+        }
+
+        return array('xf_bdbank_value_rate' => $this->_getValueRateModel()->getValueRateById($id));
+    }
+
+    protected function _getUpdateCondition($tableName)
+    {
+        $conditions = array();
+
+        foreach (array('rate_id') as $field) {
+            $conditions[] = $field . ' = ' . $this->_db->quote($this->getExisting($field));
+        }
+
+        return implode(' AND ', $conditions);
+    }
+
+    protected function _getValueRateModel()
+    {
+        /** @var bdBank_Model_ValueRate $model */
+        $model = $this->getModelFromCache('bdBank_Model_ValueRate');
+
+        return $model;
+    }
+
+    /* End auto-generated lines of code. Feel free to make changes below */
+}

--- a/library/bdBank/DevHelper/Config.php
+++ b/library/bdBank/DevHelper/Config.php
@@ -110,11 +110,30 @@ class bdBank_DevHelper_Config extends DevHelper_Config_Base
             'title_field' => 'stats_key',
             'primaryKey' => false,
             'indeces' => array(),
+            'files' => array('data_writer' => false, 'model' => false, 'route_prefix_admin' => false, 'controller_admin' => false),
+        ),
+        'value_rate' => array(
+            'name' => 'value_rate',
+            'camelCase' => 'ValueRate',
+            'camelCasePlural' => 'ValueRates',
+            'camelCaseWSpace' => 'Value Rate',
+            'camelCasePluralWSpace' => 'Value Rates',
+            'fields' => array(
+                'rate_id' => array('name' => 'rate_id', 'type' => 'uint', 'autoIncrement' => true),
+                'rate' => array('name' => 'rate', 'type' => 'float', 'required' => true),
+                'valid_to' => array('name' => 'valid_to', 'type' => 'uint', 'required' => true),
+            ),
+            'phrases' => array(),
+            'title_field' => false,
+            'primaryKey' => array('rate_id'),
+            'indeces' => array(
+                'valid_to' => array('name' => 'valid_to', 'fields' => array('valid_to'), 'type' => 'UNIQUE'),
+            ),
             'files' => array(
-                'data_writer' => false,
-                'model' => false,
-                'route_prefix_admin' => false,
-                'controller_admin' => false
+                'data_writer' => array('className' => 'bdBank_DataWriter_ValueRate', 'hash' => 'a7500b84940a0a7b72395a4e299cbadb'),
+                'model' => array('className' => 'bdBank_Model_ValueRate', 'hash' => '852306145c710e0688752b17a97731df'),
+                'route_prefix_admin' => array('className' => 'bdBank_Route_PrefixAdmin_ValueRate', 'hash' => '439273bc05d9ebeb686367a37c4908ec'),
+                'controller_admin' => array('className' => 'bdBank_ControllerAdmin_ValueRate', 'hash' => 'cb3acc79b43f1d83e6bf9bc3b37d58f9'),
             ),
         ),
     );

--- a/library/bdBank/Installer.php
+++ b/library/bdBank/Installer.php
@@ -59,6 +59,16 @@ class bdBank_Installer
             ) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;',
             'dropQuery' => 'DROP TABLE IF EXISTS `xf_bdbank_stats`',
         ),
+        'value_rate' => array(
+            'createQuery' => 'CREATE TABLE IF NOT EXISTS `xf_bdbank_value_rate` (
+                `rate_id` INT(10) UNSIGNED AUTO_INCREMENT
+                ,`rate` FLOAT NOT NULL
+                ,`valid_to` INT(10) UNSIGNED NOT NULL
+                , PRIMARY KEY (`rate_id`)
+                ,UNIQUE INDEX `valid_to` (`valid_to`)
+            ) ENGINE = InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;',
+            'dropQuery' => 'DROP TABLE IF EXISTS `xf_bdbank_value_rate`',
+        ),
     );
     protected static $_patches = array(
         array(
@@ -67,6 +77,7 @@ class bdBank_Installer
             'field' => 'bdbank_money',
             'checkQuery' => 'SHOW COLUMNS FROM `xf_user` LIKE \'bdbank_money\'',
             'addQuery' => 'ALTER TABLE `xf_user` ADD COLUMN `bdbank_money` DECIMAL(13,4) DEFAULT \'0\'',
+            'modifyQuery' => 'ALTER TABLE `xf_user` MODIFY COLUMN `bdbank_money` DECIMAL(13,4) DEFAULT \'0\'',
             'dropQuery' => 'ALTER TABLE `xf_user` DROP COLUMN `bdbank_money`',
         ),
         array(
@@ -75,6 +86,7 @@ class bdBank_Installer
             'field' => 'bdbank_options',
             'checkQuery' => 'SHOW COLUMNS FROM `xf_forum` LIKE \'bdbank_options\'',
             'addQuery' => 'ALTER TABLE `xf_forum` ADD COLUMN `bdbank_options` MEDIUMBLOB',
+            'modifyQuery' => 'ALTER TABLE `xf_forum` MODIFY COLUMN `bdbank_options` MEDIUMBLOB',
             'dropQuery' => 'ALTER TABLE `xf_forum` DROP COLUMN `bdbank_options`',
         ),
         array(
@@ -83,6 +95,7 @@ class bdBank_Installer
             'field' => 'bdbank_show_money',
             'checkQuery' => 'SHOW COLUMNS FROM `xf_user_option` LIKE \'bdbank_show_money\'',
             'addQuery' => 'ALTER TABLE `xf_user_option` ADD COLUMN `bdbank_show_money` INT(10) UNSIGNED DEFAULT \'1\'',
+            'modifyQuery' => 'ALTER TABLE `xf_user_option` MODIFY COLUMN `bdbank_show_money` INT(10) UNSIGNED DEFAULT \'1\'',
             'dropQuery' => 'ALTER TABLE `xf_user_option` DROP COLUMN `bdbank_show_money`',
         ),
         array(
@@ -120,6 +133,8 @@ class bdBank_Installer
             $existed = $db->fetchOne($patch['checkQuery']);
             if (empty($existed)) {
                 $db->query($patch['addQuery']);
+            } elseif (!empty($patch['modifyQuery'])) {
+                $db->query($patch['modifyQuery']);
             }
         }
 

--- a/library/bdBank/Model/Rebuilder.php
+++ b/library/bdBank/Model/Rebuilder.php
@@ -174,6 +174,7 @@ class bdBank_Model_Rebuilder
             $position = $like['like_id'];
 
             $comment = $bank->comment('liked_' . $like['content_type'], $like['content_id'], $like['like_user_id']);
+            $point = $bank->scalePointsByTime($point, $like['like_date']);
             $reverseResult = $bank->reverseSystemTransactionByComment($comment, $point);
             if (count($reverseResult['skipped']) > 0) {
                 continue;

--- a/library/bdBank/Model/ValueRate.php
+++ b/library/bdBank/Model/ValueRate.php
@@ -1,0 +1,154 @@
+<?php
+
+class bdBank_Model_ValueRate extends XenForo_Model
+{
+
+    /* Start auto-generated lines of code. Change made will be overwriten... */
+
+    public function getList(array $conditions = array(), array $fetchOptions = array())
+    {
+        $valueRates = $this->getValueRates($conditions, $fetchOptions);
+        $list = array();
+
+        foreach ($valueRates as $id => $valueRate) {
+            $list[$id] = $valueRate['rate_id'];
+        }
+
+        return $list;
+    }
+
+    public function getValueRateById($id, array $fetchOptions = array())
+    {
+        $valueRates = $this->getValueRates(array('rate_id' => $id), $fetchOptions);
+
+        return reset($valueRates);
+    }
+
+    public function getValueRateIdsInRange($start, $limit)
+    {
+        $db = $this->_getDb();
+
+        return $db->fetchCol($db->limit('
+            SELECT rate_id
+            FROM xf_bdbank_value_rate
+            WHERE rate_id > ?
+            ORDER BY rate_id
+        ', $limit), $start);
+    }
+
+    public function getValueRates(array $conditions = array(), array $fetchOptions = array())
+    {
+        $whereConditions = $this->prepareValueRateConditions($conditions, $fetchOptions);
+
+        $orderClause = $this->prepareValueRateOrderOptions($fetchOptions);
+        $joinOptions = $this->prepareValueRateFetchOptions($fetchOptions);
+        $limitOptions = $this->prepareLimitFetchOptions($fetchOptions);
+
+        $valueRates = $this->fetchAllKeyed($this->limitQueryResults("
+            SELECT value_rate.*
+                $joinOptions[selectFields]
+            FROM `xf_bdbank_value_rate` AS value_rate
+                $joinOptions[joinTables]
+            WHERE $whereConditions
+                $orderClause
+            ", $limitOptions['limit'], $limitOptions['offset']), 'rate_id');
+
+        $this->_getValueRatesCustomized($valueRates, $fetchOptions);
+
+        return $valueRates;
+    }
+
+    public function countValueRates(array $conditions = array(), array $fetchOptions = array())
+    {
+        $whereConditions = $this->prepareValueRateConditions($conditions, $fetchOptions);
+
+        $orderClause = $this->prepareValueRateOrderOptions($fetchOptions);
+        $joinOptions = $this->prepareValueRateFetchOptions($fetchOptions);
+        $limitOptions = $this->prepareLimitFetchOptions($fetchOptions);
+
+        return $this->_getDb()->fetchOne("
+            SELECT COUNT(*)
+            FROM `xf_bdbank_value_rate` AS value_rate
+                $joinOptions[joinTables]
+            WHERE $whereConditions
+        ");
+    }
+
+    public function prepareValueRateConditions(array $conditions = array(), array $fetchOptions = array())
+    {
+        $sqlConditions = array();
+        $db = $this->_getDb();
+
+        if (isset($conditions['rate_id'])) {
+            if (is_array($conditions['rate_id'])) {
+                if (!empty($conditions['rate_id'])) {
+                    // only use IN condition if the array is not empty (nasty!)
+                    $sqlConditions[] = "value_rate.rate_id IN (" . $db->quote($conditions['rate_id']) . ")";
+                }
+            } else {
+                $sqlConditions[] = "value_rate.rate_id = " . $db->quote($conditions['rate_id']);
+            }
+        }
+
+        if (isset($conditions['valid_to'])) {
+            if (is_array($conditions['valid_to'])) {
+                if (!empty($conditions['valid_to'])) {
+                    // only use IN condition if the array is not empty (nasty!)
+                    $sqlConditions[] = "value_rate.valid_to IN (" . $db->quote($conditions['valid_to']) . ")";
+                }
+            } else {
+                $sqlConditions[] = "value_rate.valid_to = " . $db->quote($conditions['valid_to']);
+            }
+        }
+
+        $this->_prepareValueRateConditionsCustomized($sqlConditions, $conditions, $fetchOptions);
+
+        return $this->getConditionsForClause($sqlConditions);
+    }
+
+    public function prepareValueRateFetchOptions(array $fetchOptions = array())
+    {
+        $selectFields = '';
+        $joinTables = '';
+
+        $this->_prepareValueRateFetchOptionsCustomized($selectFields, $joinTables, $fetchOptions);
+
+        return array(
+            'selectFields' => $selectFields,
+            'joinTables' => $joinTables
+        );
+    }
+
+    public function prepareValueRateOrderOptions(array $fetchOptions = array(), $defaultOrderSql = '')
+    {
+        $choices = array();
+
+        $this->_prepareValueRateOrderOptionsCustomized($choices, $fetchOptions);
+
+        return $this->getOrderByClause($choices, $fetchOptions, $defaultOrderSql);
+    }
+
+    /* End auto-generated lines of code. Feel free to make changes below */
+
+    protected function _getAllValueRateCustomized(array &$data, array $fetchOptions)
+    {
+        // customized code goes here
+    }
+
+    protected function _prepareValueRateConditionsCustomized(array &$sqlConditions, array $conditions, array $fetchOptions)
+    {
+        // customized code goes here
+    }
+
+    protected function _prepareValueRateFetchOptionsCustomized(&$selectFields, &$joinTables, array $fetchOptions)
+    {
+        // customized code goes here
+    }
+
+    protected function _prepareValueRateOrderOptionsCustomized(array &$choices, array &$fetchOptions)
+    {
+        $choices = array(
+            'valid_to' => 'value_rate.valid_to'
+        );
+    }
+}

--- a/library/bdBank/Route/PrefixAdmin/ValueRate.php
+++ b/library/bdBank/Route/PrefixAdmin/ValueRate.php
@@ -1,0 +1,28 @@
+<?php
+
+class bdBank_Route_PrefixAdmin_ValueRate implements XenForo_Route_Interface
+{
+
+    /* Start auto-generated lines of code. Change made will be overwriten... */
+
+    public function match($routePath, Zend_Controller_Request_Http $request, XenForo_Router $router)
+    {
+        if (in_array($routePath, array('add', 'save'))) {
+            $action = $routePath;
+        } else {
+            $action = $router->resolveActionWithIntegerParam($routePath, $request, 'rate_id');
+        }
+        return $router->getRouteMatch('bdBank_ControllerAdmin_ValueRate', $action, '[bd] Banking');
+    }
+
+    public function buildLink($originalPrefix, $outputPrefix, $action, $extension, $data, array &$extraParams)
+    {
+        if (is_array($data)) {
+            return XenForo_Link::buildBasicLinkWithIntegerParam($outputPrefix, $action, $extension, $data, 'rate_id');
+        } else {
+            return XenForo_Link::buildBasicLink($outputPrefix, $action, $extension);
+        }
+    }
+
+    /* End auto-generated lines of code. Feel free to make changes below */
+}

--- a/library/bdBank/addon-bdbank.xml
+++ b/library/bdBank/addon-bdbank.xml
@@ -381,6 +381,80 @@
 	<input type="hidden" name="bdbank_money_included" value="1" />
 </fieldset>
 </xen:if>]]></template>
+    <template title="bdbank_value_rate_delete"><![CDATA[<xen:title>{xen:phrase bdbank_value_rate_confirm_deletion}: {$valueRate.rate_id}</xen:title>
+<xen:h1>{xen:phrase bdbank_value_rate_confirm_deletion}</xen:h1>
+
+<xen:navigation>
+	<xen:breadcrumb href="{xen:adminlink 'value-rates/edit', $valueRate}">{$valueRate.rate_id}</xen:breadcrumb>
+</xen:navigation>
+
+<xen:require css="delete_confirmation.css" />
+
+<xen:form action="{xen:adminlink 'value-rates/delete', $valueRate}" class="deleteConfirmForm formOverlay">
+
+	<p>{xen:phrase bdbank_value_rate_please_confirm}:</p>
+	<strong><a href="{xen:adminlink 'value-rates/edit', $valueRate}">{$valueRate.rate_id}</a></strong>
+
+	<xen:submitunit save="{xen:phrase bdbank_value_rate_delete}" />
+
+	<input type="hidden" name="_xfConfirm" value="1" />
+</xen:form>]]></template>
+    <template title="bdbank_value_rate_edit"><![CDATA[<xen:title>{xen:if '{$valueRate.rate_id}', '{xen:phrase bdbank_value_rate_edit}', '{xen:phrase bdbank_value_rate_add}'}</xen:title>
+
+<xen:form action="{xen:adminlink 'value-rates/save'}" class="AutoValidator" data-redirect="yes">
+
+	
+	<xen:textboxunit label="{xen:phrase bdbank_rate}:" name="rate" value="{$valueRate.rate}" />
+	<xen:textboxunit label="{xen:phrase bdbank_valid_to}:" name="valid_to" value="{$valueRate.valid_to}" />
+
+	<xen:submitunit save="{xen:phrase bdbank_value_rate_save}">
+		<input type="button" name="delete" value="{xen:phrase bdbank_value_rate_delete}"
+			accesskey="d" class="button OverlayTrigger"
+			data-href="{xen:adminlink 'value-rates/delete', $valueRate}"
+			{xen:if '!{$valueRate.rate_id}', 'style="display: none"'}
+		/>
+	</xen:submitunit>
+
+	<input type="hidden" name="rate_id" value="{$valueRate.rate_id}" />
+</xen:form>]]></template>
+    <template title="bdbank_value_rate_list"><![CDATA[<xen:title>{xen:phrase bdbank_value_rates}</xen:title>
+
+<xen:topctrl>
+	<a href="{xen:adminlink 'value-rates/add'}" class="button" accesskey="a">+ {xen:phrase bdbank_value_rate_add}</a>
+</xen:topctrl>
+
+<xen:require css="filter_list.css" />
+<xen:require js="js/xenforo/filter_list.js" />
+
+<xen:form action="{xen:adminlink 'value-rates'}" class="section">
+	<xen:if is="{$allValueRate}">
+		<h2 class="subHeading">
+			<xen:include template="filter_list_controls" />
+			{xen:phrase bdbank_value_rates}
+		</h2>
+
+		<ol class="FilterList Scrollable">
+			<xen:include template="bdbank_value_rate_list_items" />
+		</ol>
+
+		<p class="sectionFooter">
+			{xen:phrase showing_x_of_y_items,
+				'count=<span class="FilterListCount">{xen:count $allValueRate}</span>',
+				'total={xen:count $allValueRate}'
+			}
+		</p>
+	<xen:else />
+		<div class="noResults">{xen:phrase bdbank_value_rate_no_results}</div>
+	</xen:if>
+</xen:form>]]></template>
+    <template title="bdbank_value_rate_list_items"><![CDATA[<xen:foreach loop="$allValueRate" value="$valueRate">
+	<xen:listitem
+		id="{$valueRate.rate_id}"
+		href="{xen:adminlink 'value-rates/edit', $valueRate}"
+		delete="{xen:adminlink 'value-rates/delete', $valueRate}">
+		<xen:label>{$valueRate.rate_id}</xen:label>
+	</xen:listitem>
+</xen:foreach>]]></template>
     <template title="bdbank_widget_options_richest_users"><![CDATA[<xen:spinboxunit label="{xen:phrase wf_limit}:"
 				 name="{$namePrefix}limit"
 				 value="{xen:if '!empty({$options.limit})', $options.limit, 5}"
@@ -696,6 +770,7 @@ eur=40</default_value>
     <phrase title="bdbank_privacy" version_id="6" version_string="0.9.6"><![CDATA[Bank Privacy]]></phrase>
     <phrase title="bdbank_privacy_show_money" version_id="6" version_string="0.9.6"><![CDATA[Show {money_lowercase}]]></phrase>
     <phrase title="bdbank_purchase_x" version_id="14" version_string="0.11.2"><![CDATA[Purchase {item}]]></phrase>
+    <phrase title="bdbank_rate" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Rate]]></phrase>
     <phrase title="bdbank_rebuild_bonuses" version_id="10" version_string="0.9.9.2"><![CDATA[[bd] Banking - Rebuild Bonuses]]></phrase>
     <phrase title="bdbank_rebuild_bonuses_explain" version_id="10" version_string="0.9.9.2"><![CDATA[After rebuilding bonuses, you MUST rebuild user account information!]]></phrase>
     <phrase title="bdbank_rebuild_bonuses_message" version_id="10" version_string="0.9.9.2"><![CDATA[[bd] Banking - Bonuses]]></phrase>
@@ -758,6 +833,17 @@ eur=40</default_value>
     <phrase title="bdbank_user_has_at_least_x_of_y" version_id="10" version_string="0.9.9.1"><![CDATA[User has at least X of {money_lowercase}]]></phrase>
     <phrase title="bdbank_user_x" global_cache="1" version_id="5" version_string="0.9.5"><![CDATA[User #{id}]]></phrase>
     <phrase title="bdbank_use_forum_based_value_instead_of_default_x" version_id="6" version_string="0.9.6"><![CDATA[Use forum-based value instead of system-wide value (set at {value})]]></phrase>
+    <phrase title="bdbank_valid_to" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Valid To]]></phrase>
+    <phrase title="bdbank_value_rate" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Value Rate]]></phrase>
+    <phrase title="bdbank_value_rates" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Value Rates]]></phrase>
+    <phrase title="bdbank_value_rate_add" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Add New Value Rate]]></phrase>
+    <phrase title="bdbank_value_rate_confirm_deletion" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Confirm Deletion of Value Rate]]></phrase>
+    <phrase title="bdbank_value_rate_delete" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Delete Value Rate]]></phrase>
+    <phrase title="bdbank_value_rate_edit" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Edit Value Rate]]></phrase>
+    <phrase title="bdbank_value_rate_not_found" version_id="2000010" version_string="2.0.0-dev"><![CDATA[The requested value rate could not be found]]></phrase>
+    <phrase title="bdbank_value_rate_no_results" version_id="2000010" version_string="2.0.0-dev"><![CDATA[No value rate could be found...]]></phrase>
+    <phrase title="bdbank_value_rate_please_confirm" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Please confirm that you want to delete the following value rate]]></phrase>
+    <phrase title="bdbank_value_rate_save" version_id="2000010" version_string="2.0.0-dev"><![CDATA[Save Value Rate]]></phrase>
     <phrase title="bdbank_when_payment_has_been_approved_fund_will_be_transfered" version_id="14" version_string="0.11.2"><![CDATA[When the payment has been approved, the requested fund will be transfered to and made available for your account.]]></phrase>
     <phrase title="bdbank_your_accounts" version_id="1" version_string="beta"><![CDATA[Your Accounts]]></phrase>
     <phrase title="bdbank_your_balance" version_id="1" version_string="beta"><![CDATA[Your Balance]]></phrase>
@@ -846,6 +932,7 @@ Transfer $1000. Tax = ($500 - $50) * 5% + ($1000 - $500) * 10% = $72.5 = $73<br/
   <route_prefixes>
     <route_type type="admin">
       <prefix original_prefix="bank" class="bdBank_Route_PrefixAdmin_Bank" build_link="data_only"/>
+      <prefix original_prefix="value-rates" class="bdBank_Route_PrefixAdmin_ValueRate" build_link="data_only"/>
     </route_type>
     <route_type type="public">
       <prefix original_prefix="bank" class="bdBank_Route_Prefix_Public" build_link="data_only"/>


### PR DESCRIPTION
## Specifications
We want to scale up/down the points that were acquired in earlier time periods in order to balance the Tinhte's point economy.  
**Example**
* Each point acquired before 2018 should worth 0.3 x value of point in current time
* Each point acquired before 2019 should worth 0.8 x value of point in current time

## Technical Design
### Database tables
**value_rate**
* rate_id
* rate (float)
* valid_to (uint)
### Execution
When rebuilding bonuses, each point will be scaled up/down based on the time it was acquired: `scaled_point = point * value_rate`.  
Logic to determine the value_rate:
```php
// $valueRates are all value_rate records sorted by valid_to DESC
foreach ($valueRates as $valueRate) {
  if ($valueRate['valid_to'] >= $time_when_point_was_acquired) {
    return $valueRate['rate'];
  }
}
return 1;
```